### PR TITLE
fix(deliveroo): handle UK API type differences

### DIFF
--- a/internal/deliveroo/format.go
+++ b/internal/deliveroo/format.go
@@ -2,6 +2,7 @@ package deliveroo
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -11,8 +12,8 @@ func (o Order) Summary() string {
 	if o.ID != "" {
 		parts = append(parts, "id="+o.ID)
 	}
-	if o.OrderNumber != "" {
-		parts = append(parts, "number="+o.OrderNumber)
+	if o.OrderNumber != 0 {
+		parts = append(parts, "number="+strconv.Itoa(o.OrderNumber))
 	}
 	if o.Status != "" {
 		parts = append(parts, "status="+o.Status)
@@ -20,11 +21,11 @@ func (o Order) Summary() string {
 	if o.Restaurant != nil && o.Restaurant.Name != "" {
 		parts = append(parts, "restaurant="+o.Restaurant.Name)
 	}
-	if o.Total != nil {
+	if o.Total != "" {
 		if o.CurrencySymbol != "" {
-			parts = append(parts, fmt.Sprintf("total=%s%.2f", o.CurrencySymbol, *o.Total))
+			parts = append(parts, fmt.Sprintf("total=%s%s", o.CurrencySymbol, o.Total))
 		} else {
-			parts = append(parts, fmt.Sprintf("total=%.2f", *o.Total))
+			parts = append(parts, "total="+o.Total)
 		}
 	}
 	if o.EstimatedDeliveryAt != "" {

--- a/internal/deliveroo/format_test.go
+++ b/internal/deliveroo/format_test.go
@@ -5,13 +5,12 @@ import "testing"
 func TestOrderSummary(t *testing.T) {
 	t.Parallel()
 
-	total := 12.5
 	o := Order{
 		ID:                  "id",
-		OrderNumber:         "n",
+		OrderNumber:         123,
 		Status:              "delivered",
 		Restaurant:          &Restaurant{Name: "R"},
-		Total:               &total,
+		Total:               "12.50",
 		CurrencySymbol:      "€",
 		EstimatedDeliveryAt: "2025-12-20T01:00:00Z",
 		SubmittedAt:         "2025-12-20T00:00:00Z",

--- a/internal/deliveroo/model.go
+++ b/internal/deliveroo/model.go
@@ -7,7 +7,7 @@ type OrdersResponse struct {
 
 type Order struct {
 	ID                  string      `json:"id"`
-	OrderNumber         string      `json:"order_number"`
+	OrderNumber         int         `json:"order_number"`
 	Status              string      `json:"status"`
 	StatusTimestamp     string      `json:"status_timestamp"`
 	OrderType           string      `json:"order_type"`
@@ -15,8 +15,8 @@ type Order struct {
 	EstimatedDeliveryAt string      `json:"estimated_delivery_at"`
 	DeliveredAt         string      `json:"delivered_at"`
 	SubmittedAt         string      `json:"submitted_at"`
-	Total               *float64    `json:"total"`
-	OriginalTotal       *float64    `json:"original_total"`
+	Total               string      `json:"total"`
+	OriginalTotal       string      `json:"original_total"`
 	CurrencySymbol      string      `json:"currency_symbol"`
 	CurrencyCode        string      `json:"currency_code"`
 	Restaurant          *Restaurant `json:"restaurant"`


### PR DESCRIPTION
## Summary

Fixes JSON unmarshaling errors when using `ordercli deliveroo history` with UK accounts.

## Problem

The UK Deliveroo API returns different types than expected:
- `order_number`: returned as `int`, model expected `string`
- `total`: returned as `string` (e.g., `"19.64"`), model expected `*float64`

This caused errors like:
```
json: cannot unmarshal number into Go struct field Order.orders.order_number of type string
```

## Changes

- `internal/deliveroo/model.go`: Changed `OrderNumber` to `int`, `Total`/`OriginalTotal` to `string`
- `internal/deliveroo/format.go`: Updated Summary() to handle new types
- `internal/deliveroo/format_test.go`: Updated test fixtures

## Testing

Tested with a real UK Deliveroo account:
```
$ ordercli deliveroo history --limit 3
id=50547707756 number=7756 status=DELIVERED restaurant=Sacro Cuore total=£19.64
id=50502752644 number=2644 status=DELIVERED restaurant=Thai Express total=£45.18
id=50500420138 number=138 status=DELIVERED restaurant=Sacro Cuore total=£37.95
```

Fixes #2