### PR TITLE
chore: refresh dependencies and repair npm native setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
           cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Dependencies: update Go to 1.26, npm to 12.0.1, Playwright to 1.61.1, current Go terminal/system libraries, and cached Chrome cookie support to 3.0.2 with audited transitive overrides.
+- Dependencies: update Go to 1.27, Docker Node to 26.8.1, npm to 12.0.2, Playwright to 1.62.1, current Go terminal/system libraries, and cached Chrome cookie support to 3.0.2 with audited transitive overrides (tar 7.5.22).
+- Chrome cookies: explicitly approve native dependency builds for npm 12 and rebuild cached installs that skipped them.
 - Docker: add a local image with Node, Playwright Chromium, `/data` persistence, and CI smoke coverage.
 - Add Sweden (`SE`) Foodora preset using `OP_SE`. (`#4`, thanks `@grenish`)
 - Add Czech Republic (`CZ`) Foodora preset using `DJ_CZ`. (`#6`, thanks `@usimic`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-# syntax=docker/dockerfile:1.7
+# syntax=docker/dockerfile:1.26
 
-ARG GO_VERSION=1.26
-ARG NPM_VERSION=12.0.1
-ARG PLAYWRIGHT_VERSION=1.61.1
+ARG GO_VERSION=1.27
+ARG NPM_VERSION=12.0.2
+ARG PLAYWRIGHT_VERSION=1.62.1
 
 FROM golang:${GO_VERSION}-bookworm AS build
 WORKDIR /src
@@ -11,7 +11,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/ordercli ./cmd/ordercli
 
-FROM node:24.18.0-bookworm-slim
+FROM node:26.8.1-bookworm-slim
 ARG NPM_VERSION
 ARG PLAYWRIGHT_VERSION
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,10 @@ test:
 
 tools:
 	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
 fmt:
 	gofumpt -w .
 
 lint:
 	golangci-lint run
-

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Config lives in your OS config dir by default; override for testing:
 
 ## Build
 
+Requires Go 1.27 or newer.
+
 ```sh
 go test ./...
 go build ./cmd/ordercli
@@ -31,7 +33,7 @@ docker run --rm -v "$PWD/.ordercli:/data" ordercli foodora config show
 docker run --rm -it -v "$PWD/.ordercli:/data" ordercli foodora login --email you@example.com --password-stdin --browser
 ```
 
-The image includes Node and Playwright Chromium for browser-backed login/status helpers. Host Chrome cookie import still needs explicit cookie DB mounts.
+The image includes Node 26 and Playwright Chromium for browser-backed login/status helpers. Host Chrome cookie import still needs explicit cookie DB mounts.
 
 ## foodora
 
@@ -111,6 +113,8 @@ If the bot cookies live on the website domain (e.g. `https://www.foodora.at/`), 
 ```
 
 If you have multiple profiles, try `--profile "Profile 1"` (or pass a profile path / Cookies DB via `--cookie-path`).
+
+The cached cookie helper approves the pinned SQLite and Keychain native build scripts required by npm 12 and rebuilds them when refreshing its dependencies.
 
 ### Import session from Chrome (no password)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/ordercli
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/spf13/cobra v1.10.2

--- a/internal/browserauth/browserauth.go
+++ b/internal/browserauth/browserauth.go
@@ -62,7 +62,7 @@ func OAuthTokenPassword(ctx context.Context, req foodora.OAuthPasswordRequest, o
 	}
 	pw := opts.Playwright
 	if pw == "" {
-		pw = "playwright@1.61.1"
+		pw = "playwright@1.62.1"
 	}
 
 	td, err := os.MkdirTemp("", "ordercli-browserauth-*")

--- a/internal/browserpage/fetch.go
+++ b/internal/browserpage/fetch.go
@@ -50,7 +50,7 @@ func ReadText(ctx context.Context, targetURL string, opts Options) (Result, erro
 	}
 	pw := strings.TrimSpace(opts.Playwright)
 	if pw == "" {
-		pw = "playwright@1.61.1"
+		pw = "playwright@1.62.1"
 	}
 
 	td, err := os.MkdirTemp("", "ordercli-browserpage-*")

--- a/internal/browserpage/fetch_test.go
+++ b/internal/browserpage/fetch_test.go
@@ -38,7 +38,7 @@ func TestReadText_UsesDefaultsAndDecodesResult(t *testing.T) {
 		if opts.Timeout != 2*time.Minute {
 			t.Fatalf("opts timeout=%s", opts.Timeout)
 		}
-		if playwright != "playwright@1.61.1" {
+		if playwright != "playwright@1.62.1" {
 			t.Fatalf("playwright=%q", playwright)
 		}
 		return []byte(`{"final_url":"https://example.com/final","title":"T","text":"Body"}`), nil
@@ -70,7 +70,7 @@ func TestReadText_InvalidJSON(t *testing.T) {
 func TestRunFetchScript_NodeMissing(t *testing.T) {
 	t.Setenv("PATH", "")
 
-	_, err := runFetchScript(context.Background(), t.TempDir(), "script.mjs", "out.json", nil, Options{Timeout: time.Second}, "playwright@1.61.1")
+	_, err := runFetchScript(context.Background(), t.TempDir(), "script.mjs", "out.json", nil, Options{Timeout: time.Second}, "playwright@1.62.1")
 	if err == nil || !strings.Contains(err.Error(), "node not found") {
 		t.Fatalf("err=%v", err)
 	}
@@ -84,7 +84,7 @@ func TestRunFetchScript_NpmMissing(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir)
 
-	_, err := runFetchScript(context.Background(), t.TempDir(), "script.mjs", "out.json", nil, Options{Timeout: time.Second}, "playwright@1.61.1")
+	_, err := runFetchScript(context.Background(), t.TempDir(), "script.mjs", "out.json", nil, Options{Timeout: time.Second}, "playwright@1.62.1")
 	if err == nil || !strings.Contains(err.Error(), "npm not found") {
 		t.Fatalf("err=%v", err)
 	}

--- a/internal/chromecookies/chromecookies.go
+++ b/internal/chromecookies/chromecookies.go
@@ -19,8 +19,10 @@ import (
 var loadScript []byte
 
 // Keep the install-time overrides until chrome-cookies-secure drops its vulnerable build chain.
+// once v3 is ESM-only; the upstream proxy agent requires CommonJS.
+// npm 12 needs explicit approvals for the native SQLite and Keychain bindings.
 const (
-	npmPackageJSON = `{"private":true,"type":"module","dependencies":{"chrome-cookies-secure":"3.0.2"},"overrides":{"tar":"7.5.20","@tootallnate/once":"2.0.1"}}`
+	npmPackageJSON = `{"private":true,"type":"module","dependencies":{"chrome-cookies-secure":"3.0.2"},"overrides":{"tar":"7.5.22","@tootallnate/once":"2.0.1"},"allowScripts":{"sqlite3@5.1.7":true,"keytar@7.9.0":true}}`
 	npmStateFile   = ".ordercli-dependencies"
 )
 
@@ -118,20 +120,24 @@ func ensureNpmProject(ctx context.Context, dir string, logWriter io.Writer) erro
 	cmdCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 
-	install := exec.CommandContext(cmdCtx, "npm", "install", "--silent", "--no-progress", "--no-fund", "--no-audit") //nolint:gosec
-	install.Dir = dir
-	install.Stdout = io.Discard
-	if logWriter != nil {
-		install.Stderr = logWriter
-	} else {
-		install.Stderr = io.Discard
-	}
-	install.Env = append(
-		os.Environ(),
-		"npm_config_loglevel=error",
-	)
-	if err := install.Run(); err != nil {
-		return fmt.Errorf("chromecookies: npm install chrome-cookies-secure: %w", err)
+	for _, action := range []string{"install", "rebuild"} {
+		args := []string{action, "--silent", "--no-progress", "--no-fund", "--no-audit"}
+		if action == "rebuild" {
+			// Cached npm 12 installs may have skipped these scripts before approval.
+			args = append(args, "sqlite3", "keytar")
+		}
+		install := exec.CommandContext(cmdCtx, "npm", args...) //nolint:gosec
+		install.Dir = dir
+		install.Stdout = io.Discard
+		if logWriter != nil {
+			install.Stderr = logWriter
+		} else {
+			install.Stderr = io.Discard
+		}
+		install.Env = append(os.Environ(), "npm_config_loglevel=error")
+		if err := install.Run(); err != nil {
+			return fmt.Errorf("chromecookies: npm %s chrome-cookies-secure: %w", action, err)
+		}
 	}
 	if err := verifyInstalledNpmDependencies(dir); err != nil {
 		return err
@@ -158,7 +164,7 @@ func npmProjectCurrent(dir string) bool {
 func verifyInstalledNpmDependencies(dir string) error {
 	required := map[string]string{
 		"chrome-cookies-secure": "3.0.2",
-		"tar":                   "7.5.20",
+		"tar":                   "7.5.22",
 		"@tootallnate/once":     "2.0.1",
 	}
 	seen := make(map[string]bool, len(required))

--- a/internal/chromecookies/chromecookies_test.go
+++ b/internal/chromecookies/chromecookies_test.go
@@ -168,7 +168,7 @@ func TestEnsureNpmProject_Installs_WithFakeNpm(t *testing.T) {
 set -e
 mkdir -p node_modules/chrome-cookies-secure node_modules/tar node_modules/@tootallnate/once
 echo '{"name":"chrome-cookies-secure","version":"3.0.2"}' > node_modules/chrome-cookies-secure/package.json
-echo '{"name":"tar","version":"7.5.20"}' > node_modules/tar/package.json
+echo '{"name":"tar","version":"7.5.22"}' > node_modules/tar/package.json
 echo '{"name":"@tootallnate/once","version":"2.0.1"}' > node_modules/@tootallnate/once/package.json
 exit 0
 `)
@@ -188,7 +188,7 @@ exit 0
 	if err != nil {
 		t.Fatalf("read package.json: %v", err)
 	}
-	for _, want := range []string{`"chrome-cookies-secure":"3.0.2"`, `"tar":"7.5.20"`, `"@tootallnate/once":"2.0.1"`} {
+	for _, want := range []string{`"chrome-cookies-secure":"3.0.2"`, `"tar":"7.5.22"`, `"@tootallnate/once":"2.0.1"`} {
 		if !strings.Contains(string(pkg), want) {
 			t.Errorf("package.json missing %s: %s", want, pkg)
 		}
@@ -203,9 +203,10 @@ func TestEnsureNpmProject_RefreshesStaleConfig(t *testing.T) {
 	writeExe(t, filepath.Join(fakeBin, "npm"), `#!/bin/sh
 set -e
 touch npm-invoked
+echo "$*" >> npm-commands
 mkdir -p node_modules/chrome-cookies-secure node_modules/tar node_modules/@tootallnate/once
 echo '{"name":"chrome-cookies-secure","version":"3.0.2"}' > node_modules/chrome-cookies-secure/package.json
-echo '{"name":"tar","version":"7.5.20"}' > node_modules/tar/package.json
+echo '{"name":"tar","version":"7.5.22"}' > node_modules/tar/package.json
 echo '{"name":"@tootallnate/once","version":"2.0.1"}' > node_modules/@tootallnate/once/package.json
 exit 0
 `)
@@ -229,6 +230,14 @@ exit 0
 	if _, err := os.Stat(filepath.Join(dir, "npm-invoked")); err != nil {
 		t.Fatalf("expected npm reinstall: %v", err)
 	}
+	commands, err := os.ReadFile(filepath.Join(dir, "npm-commands"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "install --silent --no-progress --no-fund --no-audit\nrebuild --silent --no-progress --no-fund --no-audit sqlite3 keytar\n"
+	if string(commands) != want {
+		t.Fatalf("expected install then native binding rebuild, got %q", commands)
+	}
 }
 
 func TestVerifyInstalledNpmDependencies_RejectsStaleOverride(t *testing.T) {
@@ -249,7 +258,7 @@ func TestVerifyInstalledNpmDependencies_RejectsStaleOverride(t *testing.T) {
 	}
 
 	err := verifyInstalledNpmDependencies(dir)
-	if err == nil || !strings.Contains(err.Error(), "installed tar version 7.5.15, want 7.5.20") {
+	if err == nil || !strings.Contains(err.Error(), "installed tar version 7.5.15, want 7.5.22") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Refresh the Go, browser-helper, Docker, and CI toolchain dependencies. Live validation also exposed an npm 12 migration gap: an apparently successful cookie-helper install omitted the native SQLite/Keytar bindings. Explicit version-pinned script approvals and a targeted rebuild now repair both fresh and previously cached installs. The cache is marked current only after installation, rebuilding, and dependency verification succeed.

Dependency changes:

| Dependency | Before | After |
| --- | --- | --- |
| Go toolchain / Docker build stage | 1.26.0 / 1.26 | 1.27.0 / 1.27 |
| Docker Node | 24.18.0 | 26.8.1 |
| npm in Docker | 12.0.1 | 12.0.2 |
| Playwright (both Go helpers and Docker) | 1.61.1 | 1.62.1 |
| Chrome helper tar override | 7.5.20 | 7.5.22 |
| Dockerfile frontend | 1.7 | 1.26 |
| actions/setup-go | v6 | v7 |
| make tools golangci-lint module | v1 path | v2 path matching the existing v2 configuration |

`go get -u ./...` and `go mod tidy` confirmed the compiled Go dependencies are already current; `go.sum` is unchanged. The other Actions major tags already select their latest release lines: checkout v7, golangci-lint-action v9, and goreleaser-action v7. No dependencies were added or removed.

Major upgrades were checked against the [Node 26 release notes](https://nodejs.org/en/blog/release/v26.0.0) and [setup-go v7 notes](https://github.com/actions/setup-go/releases/tag/v7.0.0). Also checked the [Go 1.27 notes](https://go.dev/doc/go1.27) and [npm 12 script-approval contract](https://docs.npmjs.com/cli/v12/commands/npm-install-scripts/). Node 26 is proven by the built container's real Chromium fetch below. The sole deferred dependency major is `@tootallnate/once` 2.0.1 → 3.0.1: [v3 switches to ESM](https://github.com/TooTallNate/once/releases/tag/3.0.0), while the installed upstream `http-proxy-agent` requires its CommonJS callable export. Recommendation: retain the compatible 2.0.1 override until that upstream build chain migrates; replacing the cookie library is a separate design decision.

Validation:

```text
$ go build -o .git/deps-refresh-20260830/ordercli ./cmd/ordercli
(exit 0)
$ go test ./... -coverprofile=.git/deps-refresh-20260830/cover.out
(all 11 tested packages pass)
$ go tool cover -func=.git/deps-refresh-20260830/cover.out | tail -1
total: (statements) 80.3%
$ make lint
golangci-lint run
0 issues.
$ go mod verify
all modules verified
```

Live CLI proof with an isolated configuration:

```text
$ .git/deps-refresh-20260830/ordercli --config .git/deps-refresh-20260830/config.json foodora config set --country SE
(exit 0)
$ .git/deps-refresh-20260830/ordercli --config .git/deps-refresh-20260830/config.json foodora config show
base_url=https://se.fd-api.com/api/v5/
global_entity_id=OP_SE
target_country_iso=SE
device_id=1fd9a4a5-bf31-4079-a014-9583bd582b8c
$ .git/deps-refresh-20260830/ordercli --config .git/deps-refresh-20260830/config.json foodora countries
HU  NP_HU   https://hu.fd-api.com/api/v5/
SK  FP_SK   https://sk.fd-api.com/api/v5/
DL  FP_DE   https://dl.fd-api.com/api/v5/
AT  MJM_AT  https://mj.fd-api.com/api/v5/
CZ  DJ_CZ   https://cz.fd-api.com/api/v5/
SE  OP_SE   https://se.fd-api.com/api/v5/
```

Docker and real browser proof (public example page, no account credentials or personal order data):

```text
$ docker build --pull -t ordercli:deps-refresh-20260830 .
#18 naming to docker.io/library/ordercli:deps-refresh-20260830
#18 DONE 4.6s
$ docker run --rm --entrypoint node ordercli:deps-refresh-20260830 --version
v26.8.1
$ docker run --rm --entrypoint npm ordercli:deps-refresh-20260830 --version
12.0.2
$ docker run --rm ordercli:deps-refresh-20260830 --config /tmp/smoke.json deliveroo orders --status-url 'https://example.com' --json
{
  "url": "https://example.com/",
  "title": "Example Domain",
  "raw_text": "Example Domain\n\nThis domain is for use in documentation examples without needing permission. Avoid use in operations.\n\nLearn more"
}
```

Native binding proof used a task-local npm project generated from the embedded cookie-helper manifest. Before the fix, import failed with missing native bindings even though npm reported a successful install. After the pinned approvals and `npm rebuild --silent --no-progress --no-fund --no-audit sqlite3 keytar`:

```sh
node <<'JS'
const root = './.git/deps-refresh-20260830/chrome/node_modules/';
require(root + 'chrome-cookies-secure');
require(root + 'keytar');
console.log('chrome-cookies-secure + keytar imports: ok');
const sqlite3 = require(root + 'sqlite3');
const db = new sqlite3.Database(':memory:');
db.get('SELECT 42 AS answer', (err, row) => {
  if (err) throw err;
  console.log('sqlite3 query: ' + row.answer);
  db.close();
});
JS
```

```text
chrome-cookies-secure + keytar imports: ok
sqlite3 query: 42
$ npm audit --prefix .git/deps-refresh-20260830/chrome --json
metadata.vulnerabilities: {"info":0,"low":0,"moderate":0,"high":0,"critical":0,"total":0}
```

Codex autoreview completed with no accepted/actionable findings at the requested P0 scope. A regression test checks that refreshing stale dependencies installs and then rebuilds the native modules.

CI reasoning: default branch started green at `a1ec9e7`: [Go tests/coverage/lint](https://github.com/steipete/ordercli/actions/runs/31039301571) and [Docker build/smoke](https://github.com/steipete/ordercli/actions/runs/31039301431). These are the build/test workflows. The release workflow is tag/manual-only and was not run; there are no scheduled monitoring workflows. The 75% coverage gate and all jobs/assertions remain intact. PR CI passed on the first run at `27ac5a1`: [Go tests/coverage/lint](https://github.com/steipete/ordercli/actions/runs/33388812576) and [Docker build/smoke](https://github.com/steipete/ordercli/actions/runs/33388812581). This also verifies setup-go v7 on GitHub-hosted runners. This PR is for orchestrator review and is not to be merged by this worker.
