### PR TITLE
build: refresh Go patch toolchain and Docker frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.27.0", "1.27.1"]
+    env:
+      GOTOOLCHAIN: local
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version-file: go.mod
+          go-version: ${{ matrix.go-version }}
           cache: true
       - name: test + coverage (>= 75%)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Build: prefer Go 1.27.1 while retaining Go 1.27.0 source support, test both versions in CI, and update the Dockerfile frontend to 1.27.
 - Dependencies: update Go to 1.27, Docker Node to 26.8.1, npm to 12.0.2, Playwright to 1.62.1, current Go terminal/system libraries, and cached Chrome cookie support to 3.0.2 with audited transitive overrides (tar 7.5.22).
 - Chrome cookies: explicitly approve native dependency builds for npm 12 and rebuild cached installs that skipped them.
 - Docker: add a local image with Node, Playwright Chromium, `/data` persistence, and CI smoke coverage.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# syntax=docker/dockerfile:1.26
+# syntax=docker/dockerfile:1.27
 
-ARG GO_VERSION=1.27
+ARG GO_VERSION=1.27.1
 ARG NPM_VERSION=12.0.2
 ARG PLAYWRIGHT_VERSION=1.62.1
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Config lives in your OS config dir by default; override for testing:
 
 Requires Go 1.27 or newer.
 
+The preferred build toolchain is Go 1.27.1; CI also verifies the Go 1.27.0 source minimum.
+
 ```sh
 go test ./...
 go build ./cmd/ordercli

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/steipete/ordercli
 
 go 1.27.0
 
+toolchain go1.27.1
+
 require (
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/term v0.45.0


### PR DESCRIPTION
Use the Go 1.27.1 patch release for normal builds and the Docker image, while retaining the existing Go 1.27.0 source minimum. The CI test matrix now runs both compiler versions with automatic toolchain switching disabled, so the minimum-version check cannot silently upgrade itself. Also update the stable Dockerfile frontend from 1.26 to 1.27 and align the README and changelog.

The dependency audit found the runtime Go modules, Node 26.8.1, npm 12.0.2, Playwright 1.62.1, Chrome cookie helper, and Action major versions already current. No application behavior or dependency API changes are included.

Validation:
- Full Go test suite with Go 1.27.0 and Go 1.27.1: both passed; aggregate coverage 80.3% (75% required).
- Built CLI on both toolchains: help, Foodora preset/config persistence, and Deliveroo history against a synthetic loopback HTTP server passed.
- golangci-lint 2.13.2: 0 issues; go mod tidy -diff and git diff --check clean.
- Independent P0–P2 review: no actionable findings.
- Exact-head [CI](https://github.com/steipete/ordercli/actions/runs/33864676485): both Go versions and lint passed.
- Exact-head [Docker CI](https://github.com/steipete/ordercli/actions/runs/33864676482): image build and CLI/Node/npm/browser-directory smoke passed.
